### PR TITLE
Fixed color scheme delay

### DIFF
--- a/src/application/appearance.rs
+++ b/src/application/appearance.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+use libset::{format::FileFormat, project::Project};
+use relm4::adw;
+
+use crate::widgets::components::preferences::{ColorScheme, Preferences};
+pub(crate) fn init() -> Result<()> {
+	let project = Project::open("dev", "edfloreshz", "done").unwrap();
+	let preferences = project
+		.get_file_as::<Preferences>("preferences", FileFormat::JSON)
+		.unwrap();
+	let color_scheme = match preferences.color_scheme {
+		ColorScheme::Dark => adw::ColorScheme::ForceDark,
+		ColorScheme::Light => adw::ColorScheme::ForceLight,
+		ColorScheme::Default => adw::ColorScheme::Default,
+	};
+	adw::StyleManager::default().set_color_scheme(color_scheme);
+	Ok(())
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,4 +1,5 @@
 pub mod actions;
+pub mod appearance;
 pub mod gettext;
 pub mod info;
 pub mod localization;

--- a/src/application/setup.rs
+++ b/src/application/setup.rs
@@ -5,6 +5,8 @@ use anyhow::{Ok, Result};
 use once_cell::unsync::Lazy;
 use relm4::{adw, gtk, gtk::gio};
 
+use super::appearance;
+
 thread_local! {
 	static APP: Lazy<adw::Application> = Lazy::new(|| { adw::Application::new(Some(APP_ID), gio::ApplicationFlags::empty())});
 }
@@ -20,6 +22,7 @@ pub async fn init() -> Result<adw::Application> {
 	gettext::init();
 	localization::init();
 	settings::init().await?;
+	appearance::init()?;
 	pretty_env_logger::init();
 	resources::init()?;
 	services::init().await?;


### PR DESCRIPTION
This PR fixes an issue where the color scheme would be set after the app launched, it is now set before to prevent the color scheme changing in the middle of startup.

This closes #59 