### PR TITLE
Fix settings pane close button

### DIFF
--- a/src/widgets/components/preferences.rs
+++ b/src/widgets/components/preferences.rs
@@ -109,6 +109,7 @@ impl AsyncComponent for PreferencesComponentModel {
 	view! {
 		adw::PreferencesWindow {
 			set_title: Some(fl!("preferences")),
+			set_hide_on_close: true,
 			#[wrap(Some)]
 			#[name = "overlay"]
 			set_content = &adw::ToastOverlay {


### PR DESCRIPTION
This PR fixes a small bug where the settings pane would not close itself when it was opened a second time.

Closes #65 