### PR TITLE
Replace quick creation buttons with task details pane

### DIFF
--- a/src/widgets/factory/task.rs
+++ b/src/widgets/factory/task.rs
@@ -20,14 +20,14 @@ pub enum TaskFactoryInput {
 	Favorite(DynamicIndex),
 	ModifyTitle(String),
 	ToggleCompact(bool),
-	RevealTaskDetails(DynamicIndex),
+	RevealTaskDetails(Option<DynamicIndex>),
 }
 
 #[derive(Debug)]
 pub enum TaskFactoryOutput {
 	Remove(DynamicIndex),
 	UpdateTask(Option<DynamicIndex>, Task),
-	RevealTaskDetails(DynamicIndex, Task),
+	RevealTaskDetails(Option<DynamicIndex>, Task),
 }
 
 #[derive(Debug, Clone)]
@@ -93,7 +93,7 @@ impl AsyncFactoryComponent for TaskFactoryModel {
 				set_icon_name: "info-symbolic",
 				set_valign: gtk::Align::Center,
 				connect_clicked[sender, index] => move |_| {
-					sender.input(TaskFactoryInput::RevealTaskDetails(index.clone()))
+					sender.input(TaskFactoryInput::RevealTaskDetails(Some(index.clone())))
 				}
 			},
 			#[name(delete)]


### PR DESCRIPTION
This PR makes it possible for new tasks to be created in the task details pane.

![image](https://user-images.githubusercontent.com/22224438/214366269-6e43c0a9-432d-4fcf-afa8-a9c85143fd9e.png)

- New tasks can be created in the task details pane
- Fixed bugs with discard confirmation

Closes #39 