### PR TITLE
Feat: Snap Package 1/2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,47 @@
+name: done
+base: core22
+adopt-info: done
+grade: stable
+confinement: strict
+
+compression: lzo
+
+parts:
+  rustup:
+    plugin: rust
+    source: .
+    rust-channel: "1.70"
+    override-build: ''
+    override-prime: 
+
+  done:
+    after: [rustup]
+    plugin: meson
+    source: https://github.com/done-devs/done.git
+    source-tag: 'v0.2.0'
+    source-depth: 1
+    build-environment:
+      - PATH: ${HOME}/.cargo/bin:$PATH 
+    meson-parameters:
+      - --prefix=/snap/done/current/usr
+    parse-info: [usr/share/metainfo/dev.edfloreshz.Done.metainfo.xml]
+    build-packages:
+      - libssl-dev
+    organize:
+      snap/done/current: .
+
+slots:
+  done:
+    interface: dbus
+    bus: session
+    name: dev.edfloreshz.Done
+
+apps:
+  done:
+    command: usr/bin/done
+    desktop: usr/share/applications/dev.edfloreshz.Done.desktop
+    extensions: [gnome]
+    common-id: dev.edfloreshz.Done
+    plugs:
+      - home
+      - network


### PR DESCRIPTION
This initial package adds the snap manifest to this repo. To serve this in the store, kindly create an account in the [snap store](https://snapcraft.io/snaps) and register the name `done`. Also, snaps can be run as a one word command, so this app should technically run via `done` command, but as `done` is a bash keyword, it throws an error of unexpected syntax. Do you guys mind in naming the snap something else, or anything for the package itself? If not, then do you think that naming the snap as `done-app` will be good? Or do you have any other suggestion, I can change the name as needed.