### PR TITLE
snap: update the rust toolchain version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ bin
 releases
 
 .flatpak/
+
+*.snap
+done*.txt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ parts:
   rustup:
     plugin: rust
     source: .
-    rust-channel: "1.70"
+    rust-channel: "1.76"
     override-build: ''
     override-prime: 
 


### PR DESCRIPTION
This fixes the build issue. Don't know why this didn't showup in local build